### PR TITLE
Use neoutils.TransactionalCypherRunner

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 		if err != nil {
 			log.Errorf("Could not connect to neo4j, error=[%s]\n", err)
 		}
-		batchRunner := neoutils.NewBatchCypherRunner(neoutils.StringerDb{db}, *batchSize)
+		batchRunner := neoutils.NewBatchCypherRunner(neoutils.TransactionalCypherRunner{db}, *batchSize)
 		organisationsDriver := organisations.NewCypherOrganisationService(batchRunner, db)
 		organisationsDriver.Initialise()
 


### PR DESCRIPTION
Switch to neoutils.TransactionalCypherRunner to enable use of
transactions.
Note that TransactionalCypherRunner has built-in String() that behaves
identically to neoutils.StringerDb

The only testing so far is local regression testing.  No noticeable problems, no noticeable slowdown.
