### PR TITLE
Use new neoutils api

### DIFF
--- a/organisations/relationship_transfer_test.go
+++ b/organisations/relationship_transfer_test.go
@@ -2,6 +2,7 @@ package organisations
 
 import (
 	"fmt"
+	"github.com/Financial-Times/neo-utils-go/neoutils"
 	"github.com/jmcvetta/neoism"
 	"github.com/stretchr/testify/assert"
 	"strings"
@@ -233,7 +234,7 @@ func TestTransferRelationships(t *testing.T) {
 	assert.Equal("someValue", transferredProperty[0].Value)
 }
 
-func cleanRelationshipDB(db *neoism.Database, t *testing.T, assert *assert.Assertions, uuidsToClean []string) {
+func cleanRelationshipDB(db neoutils.CypherRunner, t *testing.T, assert *assert.Assertions, uuidsToClean []string) {
 	cleanDB(db, t, assert, uuidsToClean)
 
 	qs := []*neoism.CypherQuery{

--- a/organisations/relationship_transfer_test.go
+++ b/organisations/relationship_transfer_test.go
@@ -157,9 +157,9 @@ func TestGetNodeRelationshipNames(t *testing.T) {
 	}
 
 	assert.NoError(cypherDriver.Write(transferOrg1))
-	assert.NoError(cypherDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{addMentionsQuery}))
+	assert.NoError(cypherDriver.conn.CypherBatch([]*neoism.CypherQuery{addMentionsQuery}))
 
-	relationshipsFromNodeWithUUID, relationshipsToNodeWithUUID, err := getNodeRelationshipNames(cypherDriver.cypherRunner, transferOrg1UUID)
+	relationshipsFromNodeWithUUID, relationshipsToNodeWithUUID, err := getNodeRelationshipNames(cypherDriver.conn, transferOrg1UUID)
 
 	assert.NoError(err)
 	assert.True(len(relationshipsFromNodeWithUUID) >= 1, "Expected -> relationship length differs from actual length")
@@ -186,24 +186,24 @@ func TestTransferRelationships(t *testing.T) {
 		},
 	}
 	assert.NoError(cypherDriver.Write(transferOrg1))
-	assert.NoError(cypherDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{addMentionsQuery}))
+	assert.NoError(cypherDriver.conn.CypherBatch([]*neoism.CypherQuery{addMentionsQuery}))
 
 	//write new node and test that it doesn't yet have the relationships
 	assert.NoError(cypherDriver.Write(transferOrg2))
-	relationshipsFromNewNode, relationshipsToNewNode, err := getNodeRelationshipNames(cypherDriver.cypherRunner, transferOrg2UUID)
+	relationshipsFromNewNode, relationshipsToNewNode, err := getNodeRelationshipNames(cypherDriver.conn, transferOrg2UUID)
 	assert.NoError(err)
 	assert.False(contains(relationshipsFromNewNode, testRelationshipRightToLeft))
 	assert.False(contains(relationshipsToNewNode, testRelationshipRightToLeft))
 
 	//transfer relationships from the one above to the on other uuid
-	transferQuery, err := CreateTransferRelationshipsQueries(cypherDriver.cypherRunner, transferOrg2UUID, transferOrg1UUID)
+	transferQuery, err := CreateTransferRelationshipsQueries(cypherDriver.conn, transferOrg2UUID, transferOrg1UUID)
 	assert.NoError(err)
-	assert.NoError(cypherDriver.cypherRunner.CypherBatch(transferQuery))
+	assert.NoError(cypherDriver.conn.CypherBatch(transferQuery))
 
 	//verify that the relationships has been transferred
-	relationshipsFromOldNode, relationshipsToOldNode, err := getNodeRelationshipNames(cypherDriver.cypherRunner, transferOrg1UUID)
+	relationshipsFromOldNode, relationshipsToOldNode, err := getNodeRelationshipNames(cypherDriver.conn, transferOrg1UUID)
 	assert.NoError(err)
-	relationshipsFromNewNode, relationshipsToNewNode, err = getNodeRelationshipNames(cypherDriver.cypherRunner, transferOrg2UUID)
+	relationshipsFromNewNode, relationshipsToNewNode, err = getNodeRelationshipNames(cypherDriver.conn, transferOrg2UUID)
 	assert.NoError(err)
 
 	//no relationships for the old node
@@ -229,7 +229,7 @@ func TestTransferRelationships(t *testing.T) {
 		},
 		Result: &transferredProperty,
 	}
-	assert.NoError(cypherDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{readRelationshipPropertyQuery}))
+	assert.NoError(cypherDriver.conn.CypherBatch([]*neoism.CypherQuery{readRelationshipPropertyQuery}))
 	assert.Equal(1, len(transferredProperty))
 	assert.Equal("someValue", transferredProperty[0].Value)
 }

--- a/organisations/service.go
+++ b/organisations/service.go
@@ -9,18 +9,17 @@ import (
 )
 
 type service struct {
-	cypherRunner neoutils.CypherRunner
-	indexManager neoutils.IndexManager
+	cypherRunner neoutils.NeoConnection
 }
 
 //NewCypherOrganisationService returns a new service responsible for writing organisations in Neo4j
-func NewCypherOrganisationService(cypherRunner neoutils.CypherRunner, indexManager neoutils.IndexManager) service {
-	return service{cypherRunner, indexManager}
+func NewCypherOrganisationService(cypherRunner neoutils.NeoConnection) service {
+	return service{cypherRunner}
 }
 
 func (cd service) Initialise() error {
 
-	err := neoutils.EnsureIndexes(cd.indexManager,  map[string]string{
+	err := cd.cypherRunner.EnsureIndexes(map[string]string{
 		"Identifier": "value",
 	})
 
@@ -28,7 +27,7 @@ func (cd service) Initialise() error {
 		return err
 	}
 
-	return neoutils.EnsureConstraints(cd.indexManager, map[string]string{
+	return cd.cypherRunner.EnsureConstraints(map[string]string{
 		"Thing":             "uuid",
 		"Concept":           "uuid",
 		"Organisation":      "uuid",

--- a/organisations/service_concording_scenarios_test.go
+++ b/organisations/service_concording_scenarios_test.go
@@ -154,12 +154,12 @@ func TestConcordeOrganisationsWithRelationships(t *testing.T) {
 	//STEP 2: write relationships
 
 	//write V2 mentions, and about annotation for org2UUID, write V2 mentions annotation for org8UUID
-	v2AnnotationsRW := annotations.NewAnnotationsService(cypherDriver.cypherRunner, db, "v2")
+	v2AnnotationsRW := annotations.NewAnnotationsService(cypherDriver.cypherRunner, neoutils.UnderlyingDB(cypherDriver.cypherRunner), "v2")
 	assert.NoError(v2AnnotationsRW.Initialise())
 	writeJSONToService(v2AnnotationsRW, "./test-resources/annotationBodyForOrg2AndOrg8.json", contentUUID, assert)
 
 	//write V1 mentions annotation for org1UUID and org9UUID - considered as major mentions
-	v1AnnotationsRW := annotations.NewAnnotationsService(cypherDriver.cypherRunner, db, "v1")
+	v1AnnotationsRW := annotations.NewAnnotationsService(cypherDriver.cypherRunner, neoutils.UnderlyingDB(cypherDriver.cypherRunner), "v1")
 	assert.NoError(v1AnnotationsRW.Initialise())
 	writeJSONToService(v1AnnotationsRW, "./test-resources/annotationBodyForOrg1AndOrg9.json", contentUUID, assert)
 
@@ -345,7 +345,7 @@ func TestConcordeOrgsWithRelationshipPlatformVersionTransfer(t *testing.T) {
 	db := getDatabaseConnectionAndCheckClean(t, assert, concordedUUIDs)
 	cypherDriver := getCypherDriver(db)
 
-	annotationsRW := annotations.NewAnnotationsService(cypherDriver.cypherRunner, db, "v1")
+	annotationsRW := annotations.NewAnnotationsService(cypherDriver.cypherRunner, neoutils.UnderlyingDB(cypherDriver.cypherRunner), "v1")
 	assert.NoError(annotationsRW.Initialise())
 
 	defer cleanDB(db, t, assert, concordedUUIDs)
@@ -409,7 +409,7 @@ func writeJSONToService(service annotations.Service, pathToJSONFile string, cont
 	assert.NoError(errrr)
 }
 
-func deleteAllViaService(db *neoism.Database, assert *assert.Assertions, annotationsRW annotations.Service) {
+func deleteAllViaService(db neoutils.CypherRunner, assert *assert.Assertions, annotationsRW annotations.Service) {
 	_, err := annotationsRW.Delete(contentUUID)
 	assert.Nil(err)
 

--- a/organisations/service_concording_scenarios_test.go
+++ b/organisations/service_concording_scenarios_test.go
@@ -154,12 +154,12 @@ func TestConcordeOrganisationsWithRelationships(t *testing.T) {
 	//STEP 2: write relationships
 
 	//write V2 mentions, and about annotation for org2UUID, write V2 mentions annotation for org8UUID
-	v2AnnotationsRW := annotations.NewAnnotationsService(cypherDriver.cypherRunner, neoutils.UnderlyingDB(cypherDriver.cypherRunner), "v2")
+	v2AnnotationsRW := annotations.NewAnnotationsService(cypherDriver.conn, neoutils.UnderlyingDB(cypherDriver.conn), "v2")
 	assert.NoError(v2AnnotationsRW.Initialise())
 	writeJSONToService(v2AnnotationsRW, "./test-resources/annotationBodyForOrg2AndOrg8.json", contentUUID, assert)
 
 	//write V1 mentions annotation for org1UUID and org9UUID - considered as major mentions
-	v1AnnotationsRW := annotations.NewAnnotationsService(cypherDriver.cypherRunner, neoutils.UnderlyingDB(cypherDriver.cypherRunner), "v1")
+	v1AnnotationsRW := annotations.NewAnnotationsService(cypherDriver.conn, neoutils.UnderlyingDB(cypherDriver.conn), "v1")
 	assert.NoError(v1AnnotationsRW.Initialise())
 	writeJSONToService(v1AnnotationsRW, "./test-resources/annotationBodyForOrg1AndOrg9.json", contentUUID, assert)
 
@@ -196,14 +196,14 @@ func TestConcordeOrganisationsWithRelationships(t *testing.T) {
 	//	 - one v2 mentions from content - which existed
 	//	 - one SUB_ORGANISATION_OF to org8 from org2
 	//	 - 4 IDENTIFIES relationships from identifiers to nodes
-	transferredPropertyLR, transferredPropertyRL, err := readRelationshipDetails(cypherDriver.cypherRunner, "Thing", org8UUID)
+	transferredPropertyLR, transferredPropertyRL, err := readRelationshipDetails(cypherDriver.conn, "Thing", org8UUID)
 	assert.Nil(err)
 	assert.Equal(0, len(transferredPropertyRL))
 	assert.Equal(2, len(transferredPropertyLR))
 	assert.Contains(transferredPropertyLR, property{Type: "MENTIONS", PlatformVersion: "v2"})
 	assert.Contains(transferredPropertyLR, property{Type: "SUB_ORGANISATION_OF", PlatformVersion: ""})
 
-	transferredPropertyLR, transferredPropertyRL, err = readRelationshipDetails(cypherDriver.cypherRunner, "Identifier", org8UUID)
+	transferredPropertyLR, transferredPropertyRL, err = readRelationshipDetails(cypherDriver.conn, "Identifier", org8UUID)
 	assert.Nil(err)
 	assert.Equal(0, len(transferredPropertyRL))
 	assert.Equal(4, len(transferredPropertyLR))
@@ -218,7 +218,7 @@ func TestConcordeOrganisationsWithRelationships(t *testing.T) {
 	//	 - one v2 about from content
 	//	 - one SUB_ORGANISATION_OF to org8
 	//	 - 7 IDENTIFIES relationships from identifiers to node
-	transferredPropertyLR, transferredPropertyRL, err = readRelationshipDetails(cypherDriver.cypherRunner, "Thing", org1UUID)
+	transferredPropertyLR, transferredPropertyRL, err = readRelationshipDetails(cypherDriver.conn, "Thing", org1UUID)
 	assert.Nil(err)
 	assert.Equal(3, len(transferredPropertyLR))
 	assert.Contains(transferredPropertyLR, property{Type: "MENTIONS", PlatformVersion: "v2"})
@@ -227,7 +227,7 @@ func TestConcordeOrganisationsWithRelationships(t *testing.T) {
 	assert.Equal(1, len(transferredPropertyRL))
 	assert.Contains(transferredPropertyRL, property{Type: "SUB_ORGANISATION_OF", PlatformVersion: ""})
 
-	transferredPropertyLR, transferredPropertyRL, err = readRelationshipDetails(cypherDriver.cypherRunner, "Identifier", org1UUID)
+	transferredPropertyLR, transferredPropertyRL, err = readRelationshipDetails(cypherDriver.conn, "Identifier", org1UUID)
 	assert.Nil(err)
 	assert.Equal(0, len(transferredPropertyRL))
 	assert.Equal(7, len(transferredPropertyLR))
@@ -296,7 +296,7 @@ func TestTransferIncomingHasSubOrganisationOfRelationships(t *testing.T) {
 	storedOrg1, _, _ := cypherDriver.Read(org1UUID)
 	assert.Equal(updatedOrg1, storedOrg1, "orgs should be equal ")
 
-	transferredPropertyLR, transferredPropertyRL, err := readRelationshipDetails(cypherDriver.cypherRunner, "Thing", org1UUID)
+	transferredPropertyLR, transferredPropertyRL, err := readRelationshipDetails(cypherDriver.conn, "Thing", org1UUID)
 	assert.Nil(err)
 	assert.Equal(1, len(transferredPropertyLR))
 	assert.Contains(transferredPropertyLR, property{Type: "SUB_ORGANISATION_OF", PlatformVersion: ""})
@@ -345,7 +345,7 @@ func TestConcordeOrgsWithRelationshipPlatformVersionTransfer(t *testing.T) {
 	db := getDatabaseConnectionAndCheckClean(t, assert, concordedUUIDs)
 	cypherDriver := getCypherDriver(db)
 
-	annotationsRW := annotations.NewAnnotationsService(cypherDriver.cypherRunner, neoutils.UnderlyingDB(cypherDriver.cypherRunner), "v1")
+	annotationsRW := annotations.NewAnnotationsService(cypherDriver.conn, neoutils.UnderlyingDB(cypherDriver.conn), "v1")
 	assert.NoError(annotationsRW.Initialise())
 
 	defer cleanDB(db, t, assert, concordedUUIDs)
@@ -353,9 +353,9 @@ func TestConcordeOrgsWithRelationshipPlatformVersionTransfer(t *testing.T) {
 
 	assert.NoError(cypherDriver.Write(org2))
 
-	relOrg2L, relOrg2R, err := getNodeRelationshipNames(cypherDriver.cypherRunner, org2UUID)
+	relOrg2L, relOrg2R, err := getNodeRelationshipNames(cypherDriver.conn, org2UUID)
 	assert.Nil(err)
-	relOrg1L, relOrg1R, err := getNodeRelationshipNames(cypherDriver.cypherRunner, org1UUID)
+	relOrg1L, relOrg1R, err := getNodeRelationshipNames(cypherDriver.conn, org1UUID)
 	assert.Empty(relOrg1L)
 	assert.Empty(relOrg1R)
 	assert.Nil(err)
@@ -375,7 +375,7 @@ func TestConcordeOrgsWithRelationshipPlatformVersionTransfer(t *testing.T) {
 	writeJSONToService(annotationsRW, "./test-resources/annotationBodyForOrg2.json", contentUUID, assert)
 	assert.NoError(cypherDriver.Write(updatedOrg1))
 
-	relUpdatedOrg1L, relUpdatedOrg1R, err := getNodeRelationshipNames(cypherDriver.cypherRunner, org1UUID)
+	relUpdatedOrg1L, relUpdatedOrg1R, err := getNodeRelationshipNames(cypherDriver.conn, org1UUID)
 	assert.Nil(err)
 	for _, rel := range relOrg2L {
 		contains(relUpdatedOrg1L, rel.RelationshipType)
@@ -390,7 +390,7 @@ func TestConcordeOrgsWithRelationshipPlatformVersionTransfer(t *testing.T) {
 	assert.Equal(organisation{}, storedOrg2, "org should have been deleted")
 	assert.Equal(updatedOrg1, storedOrg1, "org should have been updated")
 
-	transferredPropertyLR, transferredPropertyRL, err := readRelationshipDetails(cypherDriver.cypherRunner, "Thing", org1UUID)
+	transferredPropertyLR, transferredPropertyRL, err := readRelationshipDetails(cypherDriver.conn, "Thing", org1UUID)
 	assert.Nil(err)
 	assert.Equal(2, len(transferredPropertyLR))
 	assert.Contains(transferredPropertyLR, property{Type: "MENTIONS", PlatformVersion: "v1"})

--- a/organisations/service_test.go
+++ b/organisations/service_test.go
@@ -278,7 +278,7 @@ func TestDeleteNoRelationships(t *testing.T) {
 		Result:    &result,
 	}
 
-	assert.NoError(db.Cypher(&getOrg))
+	assert.NoError(db.CypherBatch([]*neoism.CypherQuery{&getOrg}))
 	assert.Empty(result)
 }
 

--- a/organisations/test_utils.go
+++ b/organisations/test_utils.go
@@ -9,24 +9,26 @@ import (
 	"testing"
 )
 
-func getDatabaseConnection(assert *assert.Assertions) *neoism.Database {
+func getDatabaseConnection(assert *assert.Assertions) neoutils.NeoConnection {
 	url := os.Getenv("NEO4J_TEST_URL")
 	if url == "" {
 		url = "http://localhost:7474/db/data"
 	}
 
-	db, err := neoism.Connect(url)
+	conf := neoutils.DefaultConnectionConfig()
+	conf.Transactional = false
+	db, err := neoutils.Connect(url, conf)
 	assert.NoError(err, "Failed to connect to Neo4j")
 	return db
 }
 
-func getCypherDriver(db *neoism.Database) service {
-	cr := NewCypherOrganisationService(neoutils.NewBatchCypherRunner(neoutils.StringerDb{db}, 3), db)
+func getCypherDriver(db neoutils.NeoConnection) service {
+	cr := NewCypherOrganisationService(db)
 	cr.Initialise()
 	return cr
 }
 
-func getDatabaseConnectionAndCheckClean(t *testing.T, assert *assert.Assertions, uuidsToClean []string) *neoism.Database {
+func getDatabaseConnectionAndCheckClean(t *testing.T, assert *assert.Assertions, uuidsToClean []string) neoutils.NeoConnection {
 	db := getDatabaseConnection(assert)
 	cleanDB(db, t, assert, uuidsToClean)
 	checkDbClean(db, t, uuidsToClean)

--- a/organisations/test_utils.go
+++ b/organisations/test_utils.go
@@ -33,7 +33,7 @@ func getDatabaseConnectionAndCheckClean(t *testing.T, assert *assert.Assertions,
 	return db
 }
 
-func checkDbClean(db *neoism.Database, t *testing.T, uuidsToClean []string) {
+func checkDbClean(db neoutils.CypherRunner, t *testing.T, uuidsToClean []string) {
 	assert := assert.New(t)
 
 	result := []struct {
@@ -49,12 +49,12 @@ func checkDbClean(db *neoism.Database, t *testing.T, uuidsToClean []string) {
 		},
 		Result: &result,
 	}
-	err := db.Cypher(&checkGraph)
+	err := db.CypherBatch([]*neoism.CypherQuery{&checkGraph})
 	assert.NoError(err)
 	assert.Empty(result)
 }
 
-func cleanDB(db *neoism.Database, t *testing.T, assert *assert.Assertions, uuidsToClean []string) {
+func cleanDB(db neoutils.CypherRunner, t *testing.T, assert *assert.Assertions, uuidsToClean []string) {
 	qs := []*neoism.CypherQuery{}
 
 	for _, uuid := range uuidsToClean {


### PR DESCRIPTION
This updates to use the new Connect() based neoutils API.

Note that because our tests in other projects rely on our services API in here, merging this will mean that other projects tests may fail until they are updated.