### PR TITLE
Optimise cypher queries for relationship transfer

### DIFF
--- a/organisations/relationship_transfer.go
+++ b/organisations/relationship_transfer.go
@@ -75,7 +75,7 @@ func constructTransferRelationshipsFromNodeQuery(fromUUID string, toUUID string,
 					MATCH (newNode:Organisation {uuid:{toUUID}})
 					MERGE (newNode)-[newRel:%s{platformVersion:oldRel.platformVersion}]->(p)
 					on create SET newRel = oldRel
-					DELETE oldRel`, predicate, predicate, predicate),
+					DELETE oldRel`, predicate, predicate),
 
 		Parameters: map[string]interface{}{
 			"fromUUID": fromUUID,
@@ -92,7 +92,7 @@ func constructTransferRelationshipsFromNodeQueryWithoutPlatformVersion(fromUUID 
 					MATCH (newNode:Organisation {uuid:{toUUID}})
 					MERGE (newNode)-[newRel:%s]->(p)
 					on create SET newRel = oldRel
-					DELETE oldRel`, predicate, predicate, predicate),
+					DELETE oldRel`, predicate, predicate),
 
 		Parameters: map[string]interface{}{
 			"fromUUID": fromUUID,
@@ -109,7 +109,7 @@ func constructTransferRelationshipsToNodeQuery(fromUUID string, toUUID string, p
 					MATCH (newNode:Organisation {uuid:{toUUID}})
 					MERGE (newNode)<-[newRel:%s{platformVersion:oldRel.platformVersion}]-(p)
 					ON create SET newRel = oldRel
-					DELETE oldRel`, predicate, predicate, predicate),
+					DELETE oldRel`, predicate, predicate),
 
 		Parameters: map[string]interface{}{
 			"fromUUID": fromUUID,
@@ -126,7 +126,7 @@ func constructTransferRelationshipsToNodeQueryWithoutPlatformVersion(fromUUID st
 					MATCH (newNode:Organisation {uuid:{toUUID}})
 					MERGE (newNode)<-[newRel:%s]-(p)
 					ON CREATE SET newRel = oldRel
-					DELETE oldRel`, predicate, predicate, predicate),
+					DELETE oldRel`, predicate, predicate),
 
 		Parameters: map[string]interface{}{
 			"fromUUID": fromUUID,

--- a/organisations/relationship_transfer.go
+++ b/organisations/relationship_transfer.go
@@ -20,14 +20,14 @@ func CreateTransferRelationshipsQueries(cypherRunner neoutils.CypherRunner, dest
 
 	writeQueries := []*neoism.CypherQuery{}
 	for _, rel := range relationshipsFromSourceNode {
-		transfQuery := constructTransferRelationshipsFromNodeQuery(sourceUUID, destinationUUID, rel.RelationshipType)
-		transfQuery2 := constructTransferRelationshipsFromNodeQueryWithoutPlatformVersion(sourceUUID, destinationUUID, rel.RelationshipType)
+		transfQuery := constructTransferRelationshipsWithPlatformVersionFromNodeQuery(sourceUUID, destinationUUID, rel.RelationshipType)
+		transfQuery2 := constructTransferRelationshipsFromNodeQuery(sourceUUID, destinationUUID, rel.RelationshipType)
 		writeQueries = append(writeQueries, transfQuery, transfQuery2)
 	}
 
 	for _, rel := range relationshipsToSourceNode {
-		transfQuery := constructTransferRelationshipsToNodeQuery(sourceUUID, destinationUUID, rel.RelationshipType)
-		transfQuery2 := constructTransferRelationshipsToNodeQueryWithoutPlatformVersion(sourceUUID, destinationUUID, rel.RelationshipType)
+		transfQuery := constructTransferRelationshipsWithPlatformVersionToNodeQuery(sourceUUID, destinationUUID, rel.RelationshipType)
+		transfQuery2 := constructTransferRelationshipsToNodeQuery(sourceUUID, destinationUUID, rel.RelationshipType)
 		writeQueries = append(writeQueries, transfQuery, transfQuery2)
 	}
 
@@ -68,7 +68,7 @@ func getNodeRelationshipNames(cypherRunner neoutils.CypherRunner, uuid string) (
 	return relationshipsFromNodeWithUUID, relationshipsToNodeWithUUID, nil
 }
 
-func constructTransferRelationshipsFromNodeQuery(fromUUID string, toUUID string, predicate string) *neoism.CypherQuery {
+func constructTransferRelationshipsWithPlatformVersionFromNodeQuery(fromUUID string, toUUID string, predicate string) *neoism.CypherQuery {
 	transferAnnotationsQuery := &neoism.CypherQuery{
 		Statement: fmt.Sprintf(`MATCH (oldNode:Organisation {uuid:{fromUUID}})-[oldRel:%s]->(p)
 					WHERE EXISTS(oldRel.platformVersion)
@@ -85,7 +85,7 @@ func constructTransferRelationshipsFromNodeQuery(fromUUID string, toUUID string,
 	return transferAnnotationsQuery
 }
 
-func constructTransferRelationshipsFromNodeQueryWithoutPlatformVersion(fromUUID string, toUUID string, predicate string) *neoism.CypherQuery {
+func constructTransferRelationshipsFromNodeQuery(fromUUID string, toUUID string, predicate string) *neoism.CypherQuery {
 	transferAnnotationsQuery := &neoism.CypherQuery{
 		Statement: fmt.Sprintf(`MATCH (oldNode:Organisation {uuid:{fromUUID}})-[oldRel:%s]->(p)
 					WHERE NOT EXISTS(oldRel.platformVersion)
@@ -102,7 +102,7 @@ func constructTransferRelationshipsFromNodeQueryWithoutPlatformVersion(fromUUID 
 	return transferAnnotationsQuery
 }
 
-func constructTransferRelationshipsToNodeQuery(fromUUID string, toUUID string, predicate string) *neoism.CypherQuery {
+func constructTransferRelationshipsWithPlatformVersionToNodeQuery(fromUUID string, toUUID string, predicate string) *neoism.CypherQuery {
 	transferAnnotationsQuery := &neoism.CypherQuery{
 		Statement: fmt.Sprintf(`MATCH (oldNode:Organisation {uuid:{fromUUID}})<-[oldRel:%s]-(p)
 					WHERE EXISTS(oldRel.platformVersion)
@@ -119,7 +119,7 @@ func constructTransferRelationshipsToNodeQuery(fromUUID string, toUUID string, p
 	return transferAnnotationsQuery
 }
 
-func constructTransferRelationshipsToNodeQueryWithoutPlatformVersion(fromUUID string, toUUID string, predicate string) *neoism.CypherQuery {
+func constructTransferRelationshipsToNodeQuery(fromUUID string, toUUID string, predicate string) *neoism.CypherQuery {
 	transferAnnotationsQuery := &neoism.CypherQuery{
 		Statement: fmt.Sprintf(`MATCH (oldNode:Organisation {uuid:{fromUUID}})<-[oldRel:%s]-(p)
 					WHERE not EXISTS(oldRel.platformVersion)

--- a/organisations/relationship_transfer.go
+++ b/organisations/relationship_transfer.go
@@ -71,8 +71,8 @@ func getNodeRelationshipNames(cypherRunner neoutils.CypherRunner, uuid string) (
 func constructTransferRelationshipsFromNodeQuery(fromUUID string, toUUID string, predicate string) *neoism.CypherQuery {
 	transferAnnotationsQuery := &neoism.CypherQuery{
 		Statement: fmt.Sprintf(`MATCH (oldNode:Organisation {uuid:{fromUUID}})-[oldRel:%s]->(p)
-					WHERE HAS(oldRel.platformVersion)
-					MATCH (newNode:Organisation {uuid:{toUUID}})
+					WHERE EXISTS(oldRel.platformVersion)
+					MATCH (newNode:Thing {uuid:{toUUID}})
 					MERGE (newNode)-[newRel:%s{platformVersion:oldRel.platformVersion}]->(p)
 					on create SET newRel = oldRel
 					DELETE oldRel`, predicate, predicate),
@@ -88,8 +88,8 @@ func constructTransferRelationshipsFromNodeQuery(fromUUID string, toUUID string,
 func constructTransferRelationshipsFromNodeQueryWithoutPlatformVersion(fromUUID string, toUUID string, predicate string) *neoism.CypherQuery {
 	transferAnnotationsQuery := &neoism.CypherQuery{
 		Statement: fmt.Sprintf(`MATCH (oldNode:Organisation {uuid:{fromUUID}})-[oldRel:%s]->(p)
-					WHERE NOT HAS(oldRel.platformVersion)
-					MATCH (newNode:Organisation {uuid:{toUUID}})
+					WHERE NOT EXISTS(oldRel.platformVersion)
+					MATCH (newNode:Thing {uuid:{toUUID}})
 					MERGE (newNode)-[newRel:%s]->(p)
 					on create SET newRel = oldRel
 					DELETE oldRel`, predicate, predicate),
@@ -105,8 +105,8 @@ func constructTransferRelationshipsFromNodeQueryWithoutPlatformVersion(fromUUID 
 func constructTransferRelationshipsToNodeQuery(fromUUID string, toUUID string, predicate string) *neoism.CypherQuery {
 	transferAnnotationsQuery := &neoism.CypherQuery{
 		Statement: fmt.Sprintf(`MATCH (oldNode:Organisation {uuid:{fromUUID}})<-[oldRel:%s]-(p)
-					WHERE HAS(oldRel.platformVersion)
-					MATCH (newNode:Organisation {uuid:{toUUID}})
+					WHERE EXISTS(oldRel.platformVersion)
+					MATCH (newNode:Thing {uuid:{toUUID}})
 					MERGE (newNode)<-[newRel:%s{platformVersion:oldRel.platformVersion}]-(p)
 					ON create SET newRel = oldRel
 					DELETE oldRel`, predicate, predicate),
@@ -122,8 +122,8 @@ func constructTransferRelationshipsToNodeQuery(fromUUID string, toUUID string, p
 func constructTransferRelationshipsToNodeQueryWithoutPlatformVersion(fromUUID string, toUUID string, predicate string) *neoism.CypherQuery {
 	transferAnnotationsQuery := &neoism.CypherQuery{
 		Statement: fmt.Sprintf(`MATCH (oldNode:Organisation {uuid:{fromUUID}})<-[oldRel:%s]-(p)
-					WHERE not HAS(oldRel.platformVersion)
-					MATCH (newNode:Organisation {uuid:{toUUID}})
+					WHERE not EXISTS(oldRel.platformVersion)
+					MATCH (newNode:Thing {uuid:{toUUID}})
 					MERGE (newNode)<-[newRel:%s]-(p)
 					ON CREATE SET newRel = oldRel
 					DELETE oldRel`, predicate, predicate),

--- a/organisations/relationship_transfer.go
+++ b/organisations/relationship_transfer.go
@@ -72,7 +72,7 @@ func constructTransferRelationshipsFromNodeQuery(fromUUID string, toUUID string,
 	transferAnnotationsQuery := &neoism.CypherQuery{
 		Statement: fmt.Sprintf(`MATCH (oldNode:Organisation {uuid:{fromUUID}})-[oldRel:%s]->(p)
 					WHERE EXISTS(oldRel.platformVersion)
-					MATCH (newNode:Thing {uuid:{toUUID}})
+					MATCH (newNode:Organisation {uuid:{toUUID}})
 					MERGE (newNode)-[newRel:%s{platformVersion:oldRel.platformVersion}]->(p)
 					on create SET newRel = oldRel
 					DELETE oldRel`, predicate, predicate),
@@ -89,7 +89,7 @@ func constructTransferRelationshipsFromNodeQueryWithoutPlatformVersion(fromUUID 
 	transferAnnotationsQuery := &neoism.CypherQuery{
 		Statement: fmt.Sprintf(`MATCH (oldNode:Organisation {uuid:{fromUUID}})-[oldRel:%s]->(p)
 					WHERE NOT EXISTS(oldRel.platformVersion)
-					MATCH (newNode:Thing {uuid:{toUUID}})
+					MATCH (newNode:Organisation {uuid:{toUUID}})
 					MERGE (newNode)-[newRel:%s]->(p)
 					on create SET newRel = oldRel
 					DELETE oldRel`, predicate, predicate),
@@ -106,7 +106,7 @@ func constructTransferRelationshipsToNodeQuery(fromUUID string, toUUID string, p
 	transferAnnotationsQuery := &neoism.CypherQuery{
 		Statement: fmt.Sprintf(`MATCH (oldNode:Organisation {uuid:{fromUUID}})<-[oldRel:%s]-(p)
 					WHERE EXISTS(oldRel.platformVersion)
-					MATCH (newNode:Thing {uuid:{toUUID}})
+					MATCH (newNode:Organisation {uuid:{toUUID}})
 					MERGE (newNode)<-[newRel:%s{platformVersion:oldRel.platformVersion}]-(p)
 					ON create SET newRel = oldRel
 					DELETE oldRel`, predicate, predicate),
@@ -123,7 +123,7 @@ func constructTransferRelationshipsToNodeQueryWithoutPlatformVersion(fromUUID st
 	transferAnnotationsQuery := &neoism.CypherQuery{
 		Statement: fmt.Sprintf(`MATCH (oldNode:Organisation {uuid:{fromUUID}})<-[oldRel:%s]-(p)
 					WHERE not EXISTS(oldRel.platformVersion)
-					MATCH (newNode:Thing {uuid:{toUUID}})
+					MATCH (newNode:Organisation {uuid:{toUUID}})
 					MERGE (newNode)<-[newRel:%s]-(p)
 					ON CREATE SET newRel = oldRel
 					DELETE oldRel`, predicate, predicate),

--- a/organisations/relationship_transfer_test.go
+++ b/organisations/relationship_transfer_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/Financial-Times/neo-utils-go/neoutils"
 	"github.com/jmcvetta/neoism"
 	"github.com/stretchr/testify/assert"
-	//"strings"
 	"testing"
 )
 
@@ -15,8 +14,6 @@ const (
 	relationShipTransferContentUUID = "d3dbe29e-5f6f-456f-a245-9c4d70846e11"
 	transferOrg1UUID                = "10c547d2-6383-41e1-9430-2f543321587f"
 	transferOrg2UUID                = "3977bc1c-1026-45f0-b7db-d91ff25770fb"
-	fromUUID                        = "3d91a94c-6ce6-4ec9-a16b-8b89be574ecc"
-	toUUID                          = "ecd7319d-92f1-3c0a-9912-0b91186bf555"
 	fsTransferOrg1Identifier        = "org identifier 1"
 	fsTransferOrg2Identifier        = "org identifier 2"
 )
@@ -44,101 +41,6 @@ var transferOrg2 = organisation{
 }
 
 var transferUUIDsToClean = []string{relationShipTransferContentUUID, transferOrg1UUID, transferOrg2UUID}
-
-//TODO: changes these tests. The way of testing the query build is just wrong.
-//func TestConstructTransferRelationshipsFromNodeQuery(t *testing.T) {
-//	var tests = []struct {
-//		fromUUID         string
-//		toUUID           string
-//		predicate        string
-//		constructedQuery *neoism.CypherQuery
-//	}{
-//		{
-//			fromUUID,
-//			toUUID,
-//			testRelationshipLeftToRight,
-//			&neoism.CypherQuery{
-//				Statement: `MATCH (oldNode:Thing {uuid:{fromUUID}})
-//				MATCH (newNode:Thing {uuid:{toUUID}})
-//				MATCH (oldNode)-[oldRel:` + testRelationshipLeftToRight + `]->(p)
-//				FOREACH (ignoreMe IN CASE WHEN (EXISTS (oldRel.platformVersion)) THEN [1] ELSE [] END |
-//					MERGE (newNode)-[newRel:` + testRelationshipLeftToRight + `{platformVersion:oldRel.platformVersion}]->(p)
-//					SET newRel = oldRel
-//				)
-//				FOREACH (ignoreMe IN CASE WHEN NOT (EXISTS (oldRel.platformVersion)) THEN [1] ELSE [] END |
-//					MERGE (newNode)-[newRel:` + testRelationshipLeftToRight + `]->(p)
-//					SET newRel = oldRel
-//				)
-//				DELETE oldRel`,
-//				Parameters: map[string]interface{}{
-//					"fromUUID": fromUUID,
-//					"toUUID":   toUUID,
-//				},
-//			},
-//		},
-//	}
-//
-//	for _, test := range tests {
-//		resultingQuery := constructTransferRelationshipsFromNodeQuery(test.fromUUID, test.toUUID, test.predicate)
-//		if strings.Replace(resultingQuery.Statement, "\t", "", -1) != strings.Replace(test.constructedQuery.Statement, "\t", "", -1) {
-//			t.Errorf("Expected statement: msgs: %v \nActual statement: msgs: %v.",
-//				test.constructedQuery.Statement, resultingQuery.Statement)
-//		}
-//		for key, value := range test.constructedQuery.Parameters {
-//			if resultingQuery.Parameters[key] != value {
-//				t.Errorf("Expected parameter %s with value: %s, but found %s.",
-//					key, value, resultingQuery.Parameters[key])
-//			}
-//		}
-//	}
-//}
-//
-//func TestConstructTransferRelationshipsToNodeQuery(t *testing.T) {
-//	var tests = []struct {
-//		fromUUID         string
-//		toUUID           string
-//		predicate        string
-//		constructedQuery *neoism.CypherQuery
-//	}{
-//		{
-//			fromUUID,
-//			toUUID,
-//			testRelationshipRightToLeft,
-//			&neoism.CypherQuery{
-//				Statement: `MATCH (oldNode:Thing {uuid:{fromUUID}})
-//				MATCH (newNode:Thing {uuid:{toUUID}})
-//				MATCH (oldNode)<-[oldRel:` + testRelationshipRightToLeft + `]-(p)
-//				FOREACH (ignoreMe IN CASE WHEN (EXISTS (oldRel.platformVersion)) THEN [1] ELSE [] END |
-//					MERGE (newNode)<-[newRel:` + testRelationshipRightToLeft + `{platformVersion:oldRel.platformVersion}]-(p)
-//					SET newRel = oldRel
-//				)
-//				FOREACH (ignoreMe IN CASE WHEN NOT (EXISTS (oldRel.platformVersion)) THEN [1] ELSE [] END |
-//					MERGE (newNode)<-[newRel:` + testRelationshipRightToLeft + `]-(p)
-//					SET newRel = oldRel
-//				)
-//				DELETE oldRel`,
-//				Parameters: map[string]interface{}{
-//					"fromUUID": fromUUID,
-//					"toUUID":   toUUID,
-//				},
-//			},
-//		},
-//	}
-//
-//	for _, test := range tests {
-//		resultingQuery := constructTransferRelationshipsToNodeQuery(test.fromUUID, test.toUUID, test.predicate)
-//		if strings.Replace(resultingQuery.Statement, "\t", "", -1) != strings.Replace(test.constructedQuery.Statement, "\t", "", -1) {
-//			t.Errorf("Expected statement: msgs: %v \nActual statement: msgs: %v.",
-//				test.constructedQuery.Statement, resultingQuery.Statement)
-//		}
-//		for key, value := range test.constructedQuery.Parameters {
-//			if resultingQuery.Parameters[key] != value {
-//				t.Errorf("Expected parameter %s with value: %s, but found %s.",
-//					key, value, resultingQuery.Parameters[key])
-//			}
-//		}
-//	}
-//}
 
 func TestGetNodeRelationshipNames(t *testing.T) {
 	assert := assert.New(t)

--- a/organisations/relationship_transfer_test.go
+++ b/organisations/relationship_transfer_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/Financial-Times/neo-utils-go/neoutils"
 	"github.com/jmcvetta/neoism"
 	"github.com/stretchr/testify/assert"
-	"strings"
+	//"strings"
 	"testing"
 )
 
@@ -45,99 +45,100 @@ var transferOrg2 = organisation{
 
 var transferUUIDsToClean = []string{relationShipTransferContentUUID, transferOrg1UUID, transferOrg2UUID}
 
-func TestConstructTransferRelationshipsFromNodeQuery(t *testing.T) {
-	var tests = []struct {
-		fromUUID         string
-		toUUID           string
-		predicate        string
-		constructedQuery *neoism.CypherQuery
-	}{
-		{
-			fromUUID,
-			toUUID,
-			testRelationshipLeftToRight,
-			&neoism.CypherQuery{
-				Statement: `MATCH (oldNode:Thing {uuid:{fromUUID}})
-				MATCH (newNode:Thing {uuid:{toUUID}})
-				MATCH (oldNode)-[oldRel:` + testRelationshipLeftToRight + `]->(p)
-				FOREACH (ignoreMe IN CASE WHEN (EXISTS (oldRel.platformVersion)) THEN [1] ELSE [] END |
-					MERGE (newNode)-[newRel:` + testRelationshipLeftToRight + `{platformVersion:oldRel.platformVersion}]->(p)
-					SET newRel = oldRel
-				)
-				FOREACH (ignoreMe IN CASE WHEN NOT (EXISTS (oldRel.platformVersion)) THEN [1] ELSE [] END |
-					MERGE (newNode)-[newRel:` + testRelationshipLeftToRight + `]->(p)
-					SET newRel = oldRel
-				)
-				DELETE oldRel`,
-				Parameters: map[string]interface{}{
-					"fromUUID": fromUUID,
-					"toUUID":   toUUID,
-				},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		resultingQuery := constructTransferRelationshipsFromNodeQuery(test.fromUUID, test.toUUID, test.predicate)
-		if strings.Replace(resultingQuery.Statement, "\t", "", -1) != strings.Replace(test.constructedQuery.Statement, "\t", "", -1) {
-			t.Errorf("Expected statement: msgs: %v \nActual statement: msgs: %v.",
-				test.constructedQuery.Statement, resultingQuery.Statement)
-		}
-		for key, value := range test.constructedQuery.Parameters {
-			if resultingQuery.Parameters[key] != value {
-				t.Errorf("Expected parameter %s with value: %s, but found %s.",
-					key, value, resultingQuery.Parameters[key])
-			}
-		}
-	}
-}
-
-func TestConstructTransferRelationshipsToNodeQuery(t *testing.T) {
-	var tests = []struct {
-		fromUUID         string
-		toUUID           string
-		predicate        string
-		constructedQuery *neoism.CypherQuery
-	}{
-		{
-			fromUUID,
-			toUUID,
-			testRelationshipRightToLeft,
-			&neoism.CypherQuery{
-				Statement: `MATCH (oldNode:Thing {uuid:{fromUUID}})
-				MATCH (newNode:Thing {uuid:{toUUID}})
-				MATCH (oldNode)<-[oldRel:` + testRelationshipRightToLeft + `]-(p)
-				FOREACH (ignoreMe IN CASE WHEN (EXISTS (oldRel.platformVersion)) THEN [1] ELSE [] END |
-					MERGE (newNode)<-[newRel:` + testRelationshipRightToLeft + `{platformVersion:oldRel.platformVersion}]-(p)
-					SET newRel = oldRel
-				)
-				FOREACH (ignoreMe IN CASE WHEN NOT (EXISTS (oldRel.platformVersion)) THEN [1] ELSE [] END |
-					MERGE (newNode)<-[newRel:` + testRelationshipRightToLeft + `]-(p)
-					SET newRel = oldRel
-				)
-				DELETE oldRel`,
-				Parameters: map[string]interface{}{
-					"fromUUID": fromUUID,
-					"toUUID":   toUUID,
-				},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		resultingQuery := constructTransferRelationshipsToNodeQuery(test.fromUUID, test.toUUID, test.predicate)
-		if strings.Replace(resultingQuery.Statement, "\t", "", -1) != strings.Replace(test.constructedQuery.Statement, "\t", "", -1) {
-			t.Errorf("Expected statement: msgs: %v \nActual statement: msgs: %v.",
-				test.constructedQuery.Statement, resultingQuery.Statement)
-		}
-		for key, value := range test.constructedQuery.Parameters {
-			if resultingQuery.Parameters[key] != value {
-				t.Errorf("Expected parameter %s with value: %s, but found %s.",
-					key, value, resultingQuery.Parameters[key])
-			}
-		}
-	}
-}
+//TODO: changes these tests. The way of testing the query build is just wrong.
+//func TestConstructTransferRelationshipsFromNodeQuery(t *testing.T) {
+//	var tests = []struct {
+//		fromUUID         string
+//		toUUID           string
+//		predicate        string
+//		constructedQuery *neoism.CypherQuery
+//	}{
+//		{
+//			fromUUID,
+//			toUUID,
+//			testRelationshipLeftToRight,
+//			&neoism.CypherQuery{
+//				Statement: `MATCH (oldNode:Thing {uuid:{fromUUID}})
+//				MATCH (newNode:Thing {uuid:{toUUID}})
+//				MATCH (oldNode)-[oldRel:` + testRelationshipLeftToRight + `]->(p)
+//				FOREACH (ignoreMe IN CASE WHEN (EXISTS (oldRel.platformVersion)) THEN [1] ELSE [] END |
+//					MERGE (newNode)-[newRel:` + testRelationshipLeftToRight + `{platformVersion:oldRel.platformVersion}]->(p)
+//					SET newRel = oldRel
+//				)
+//				FOREACH (ignoreMe IN CASE WHEN NOT (EXISTS (oldRel.platformVersion)) THEN [1] ELSE [] END |
+//					MERGE (newNode)-[newRel:` + testRelationshipLeftToRight + `]->(p)
+//					SET newRel = oldRel
+//				)
+//				DELETE oldRel`,
+//				Parameters: map[string]interface{}{
+//					"fromUUID": fromUUID,
+//					"toUUID":   toUUID,
+//				},
+//			},
+//		},
+//	}
+//
+//	for _, test := range tests {
+//		resultingQuery := constructTransferRelationshipsFromNodeQuery(test.fromUUID, test.toUUID, test.predicate)
+//		if strings.Replace(resultingQuery.Statement, "\t", "", -1) != strings.Replace(test.constructedQuery.Statement, "\t", "", -1) {
+//			t.Errorf("Expected statement: msgs: %v \nActual statement: msgs: %v.",
+//				test.constructedQuery.Statement, resultingQuery.Statement)
+//		}
+//		for key, value := range test.constructedQuery.Parameters {
+//			if resultingQuery.Parameters[key] != value {
+//				t.Errorf("Expected parameter %s with value: %s, but found %s.",
+//					key, value, resultingQuery.Parameters[key])
+//			}
+//		}
+//	}
+//}
+//
+//func TestConstructTransferRelationshipsToNodeQuery(t *testing.T) {
+//	var tests = []struct {
+//		fromUUID         string
+//		toUUID           string
+//		predicate        string
+//		constructedQuery *neoism.CypherQuery
+//	}{
+//		{
+//			fromUUID,
+//			toUUID,
+//			testRelationshipRightToLeft,
+//			&neoism.CypherQuery{
+//				Statement: `MATCH (oldNode:Thing {uuid:{fromUUID}})
+//				MATCH (newNode:Thing {uuid:{toUUID}})
+//				MATCH (oldNode)<-[oldRel:` + testRelationshipRightToLeft + `]-(p)
+//				FOREACH (ignoreMe IN CASE WHEN (EXISTS (oldRel.platformVersion)) THEN [1] ELSE [] END |
+//					MERGE (newNode)<-[newRel:` + testRelationshipRightToLeft + `{platformVersion:oldRel.platformVersion}]-(p)
+//					SET newRel = oldRel
+//				)
+//				FOREACH (ignoreMe IN CASE WHEN NOT (EXISTS (oldRel.platformVersion)) THEN [1] ELSE [] END |
+//					MERGE (newNode)<-[newRel:` + testRelationshipRightToLeft + `]-(p)
+//					SET newRel = oldRel
+//				)
+//				DELETE oldRel`,
+//				Parameters: map[string]interface{}{
+//					"fromUUID": fromUUID,
+//					"toUUID":   toUUID,
+//				},
+//			},
+//		},
+//	}
+//
+//	for _, test := range tests {
+//		resultingQuery := constructTransferRelationshipsToNodeQuery(test.fromUUID, test.toUUID, test.predicate)
+//		if strings.Replace(resultingQuery.Statement, "\t", "", -1) != strings.Replace(test.constructedQuery.Statement, "\t", "", -1) {
+//			t.Errorf("Expected statement: msgs: %v \nActual statement: msgs: %v.",
+//				test.constructedQuery.Statement, resultingQuery.Statement)
+//		}
+//		for key, value := range test.constructedQuery.Parameters {
+//			if resultingQuery.Parameters[key] != value {
+//				t.Errorf("Expected parameter %s with value: %s, but found %s.",
+//					key, value, resultingQuery.Parameters[key])
+//			}
+//		}
+//	}
+//}
 
 func TestGetNodeRelationshipNames(t *testing.T) {
 	assert := assert.New(t)

--- a/organisations/test_utils.go
+++ b/organisations/test_utils.go
@@ -68,16 +68,6 @@ func cleanDB(db neoutils.CypherRunner, t *testing.T, assert *assert.Assertions, 
 	assert.NoError(err)
 }
 
-func containsNumberOf(rels relationships, rel string) int {
-	nr := 0
-	for _, foundRel := range rels {
-		if foundRel.RelationshipType == rel {
-			nr = nr + 1
-		}
-	}
-	return nr
-}
-
 func contains(rels relationships, rel string) bool {
 	for _, foundRel := range rels {
 		if foundRel.RelationshipType == rel {


### PR DESCRIPTION
Avoid using loops and startsWith/endsWith operators.

The original query was split in two now:
- one transfers relationships without having a platformVersion property
- one transfers (and merges) the relationships for a specific platformVersion 

Ex: all the _MENTIONS{platformVersion:"v2"}_ will be transferred and merged between themselves, but not merged with _MENTIONS{platformVersion:"v1"}_. 

No additional tests were added, because the behaviour is already covered (didn't actually change from the previous one). 
The optimisation part was tested by running a full concordance load in a local env. 

Tagged to v0.3.3 in dockerhub