### PR TITLE
Updated circle file to use official neo4j image of paramaterised version and added coveralls to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Organisations Reader/Writer for Neo4j (organisations-rw-neo4j)
+[![Circle CI](https://circleci.com/gh/Financial-Times/organisations-rw-neo4j.svg?style=shield)](https://circleci.com/gh/Financial-Times/organisations-rw-neo4j)[![Go Report Card](https://goreportcard.com/badge/github.com/Financial-Times/organisations-rw-neo4j)](https://goreportcard.com/report/github.com/Financial-Times/organisations-rw-neo4j) [![Coverage Status](https://coveralls.io/repos/github/Financial-Times/organisations-rw-neo4j/badge.svg)](https://coveralls.io/github/Financial-Times/organisations-rw-neo4j)
 
 __An API for reading/writing organisations into Neo4j. Expects the organisations json supplied to be in the format that comes out of the organisations transformer.__
 

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ dependencies:
     - go get github.com/axw/gocov/gocov; go get github.com/matm/gocov-html; go get -u github.com/jstemmer/go-junit-report
 test:
   pre:
-    - docker info; docker run -d -e "NEO4J_AUTH=none" -e "NEO4J_HEAP_MEMORY=256" -e "NEO4J_CACHE_MEMORY=256M" -p 7474:7474 -p 7473:7473 coco/ft-neo4j:latest
+    - docker info; docker run -d -e "NEO4J_AUTH=none" -e "NEO4J_HEAP_MEMORY=256" -e "NEO4J_CACHE_MEMORY=256M" -p 7474:7474 -p 7473:7473 neo4j:$NEO4J_VERSION
     - wget --retry-connrefused --no-check-certificate -T 60 $NEO4J_TEST_URL; curl $NEO4J_TEST_URL
     - go get github.com/mattn/goveralls
   override:


### PR DESCRIPTION
Tests pass on version 3.1.0
https://circleci.com/gh/Financial-Times/organisations-rw-neo4j/258